### PR TITLE
More detailed memory numbers.

### DIFF
--- a/nvml-lib.c
+++ b/nvml-lib.c
@@ -85,7 +85,7 @@ boolean initialize_gpulib(GKNVMLLib *lib)
 			lib->BIND_FUNCTION(nvmlDeviceGetFanSpeed);
 			lib->BIND_FUNCTION(nvmlDeviceGetPowerUsage);
 			lib->BIND_FUNCTION(nvmlDeviceGetUtilizationRates);
-			lib->BIND_FUNCTION(nvmlDeviceGetMemoryInfo);
+			lib->BIND_FUNCTION(nvmlDeviceGetMemoryInfo_v2);
 			lib->BIND_FUNCTION(nvmlDeviceGetPciInfo);
 			lib->BIND_FUNCTION(nvmlDeviceGetNumFans);
 			lib->BIND_FUNCTION(nvmlDeviceGetFanSpeedRPM);

--- a/nvml-lib.h
+++ b/nvml-lib.h
@@ -27,14 +27,19 @@ typedef enum { NVML_CLOCK_GFX, NVML_CLOCK_MEM = 2 } nvmlClockType_t;
 typedef enum { NVML_TEMP_GPU } nvmlSensors_t;
 
 #define NVML_API_VERSION(name, ver) (uint)(sizeof(name) | (ver << 24u))
+#define NVML_STRUCT_VERSION(data, ver) (unsigned int)(sizeof(nvml ## data ## _v ## ver ## _t) | \
+                                                      (ver << 24U))
 
 typedef void* nvmlDevice_t;
 
-typedef struct {
-	uint64 total;
-	uint64 free;
-	uint64 used;
-} nvmlMemory_t;
+typedef struct
+{
+    uint   version;      //!< Structure format version (must be 2)
+    uint64 total;        //!< Total physical device memory (in bytes)
+    uint64 reserved;     //!< Device memory (in bytes) reserved for system use (driver or firmware)
+    uint64 free;         //!< Unallocated device memory (in bytes)
+    uint64 used;         //!< Allocated device memory (in bytes).
+} nvmlMemory_v2_t;
 
 typedef struct {
 	uint gpu;
@@ -64,7 +69,7 @@ DECLARE_FUNCTION(nvmlDeviceGetTemperature, nvmlDevice_t, nvmlSensors_t, uint*);
 DECLARE_FUNCTION(nvmlDeviceGetFanSpeed, nvmlDevice_t, uint*);
 DECLARE_FUNCTION(nvmlDeviceGetPowerUsage, nvmlDevice_t, uint*);
 DECLARE_FUNCTION(nvmlDeviceGetUtilizationRates, nvmlDevice_t, nvmlUsage_t*);
-DECLARE_FUNCTION(nvmlDeviceGetMemoryInfo, nvmlDevice_t, nvmlMemory_t*);
+DECLARE_FUNCTION(nvmlDeviceGetMemoryInfo_v2, nvmlDevice_t, nvmlMemory_v2_t*);
 DECLARE_FUNCTION(nvmlDeviceGetPciInfo, nvmlDevice_t, nvmlPciInfo_t*);
 DECLARE_FUNCTION(nvmlDeviceGetNumFans, nvmlDevice_t, uint*);
 DECLARE_FUNCTION(nvmlDeviceGetFanSpeedRPM, nvmlDevice_t, nvmlFan_t*);
@@ -85,7 +90,7 @@ typedef struct {
 	nvmlDeviceGetFanSpeed_fn nvmlDeviceGetFanSpeed;
 	nvmlDeviceGetPowerUsage_fn nvmlDeviceGetPowerUsage;
 	nvmlDeviceGetUtilizationRates_fn nvmlDeviceGetUtilizationRates;
-	nvmlDeviceGetMemoryInfo_fn nvmlDeviceGetMemoryInfo;
+	nvmlDeviceGetMemoryInfo_v2_fn nvmlDeviceGetMemoryInfo_v2;
 	nvmlDeviceGetPciInfo_fn nvmlDeviceGetPciInfo;
 	nvmlDeviceGetNumFans_fn nvmlDeviceGetNumFans;
 	nvmlDeviceGetFanSpeedRPM_fn nvmlDeviceGetFanSpeedRPM;


### PR DESCRIPTION
The original `nvmlDeviceGetMemoryInfo` functions `used` data member included the sum of both memory in actual use and reserved memory. `nvmlDeviceGetMemoryInfo_v2` splits these out into different members, so we can now display them separately.